### PR TITLE
Fix filter log mapping for empty filters

### DIFF
--- a/dtop/views/log_view.py
+++ b/dtop/views/log_view.py
@@ -457,7 +457,7 @@ def prev_search_match(search_matches, current_match, line_positions, wrap_log_li
 def filter_logs(logs, filter_string, case_sensitive=False):
     """Filter logs with advanced expression support"""
     if not filter_string:
-        return logs, []  # Return original logs if no filter
+        return logs, list(range(len(logs)))  # Return original logs with mapping if no filter
     
     # Parse the filter expression
     tokens = parse_filter_expression(filter_string)


### PR DESCRIPTION
## Summary
- return full log index map when filter expression is empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684083fc9a94832d84962c4fd22de3c9