### PR TITLE
Fix config label in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ dtop automatically saves your preferences to `~/.docker_tui.json`:
 {
   "columns": {
     "widths": [20, 15, 10, 8, 8, 12, 12, 15, 15],
-    "visible": ["NAME", "IMAGE", "STATUS", "CPU%", "MEM%", "NET I/O", "DISK I/O", "CREATED", "UPTIME"]
+    "visible": ["NAME", "IMAGE", "STATUS", "CPU%", "MEM%", "NET I/O", "DISK I/O", "CREATED AT", "UPTIME"]
   },
   "log_settings": {
     "normalize": true,


### PR DESCRIPTION
## Summary
- fix config column label in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684084004d90832d9650eb05ce9346ff